### PR TITLE
React to commands API and fix sorting

### DIFF
--- a/background.js
+++ b/background.js
@@ -143,15 +143,14 @@ async function init() {
   // User has to use "customize" to remove the button, API cannot hide it.
   //await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.show_toolbar_button", true);
   await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.show_statusbar_panel", true);
-  await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.use_onbeforeunload", false);   // Remove ?
+  await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.use_onbeforeunload", false);   // Hidden pref, used?
   await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.onload_reset_noremote", true);
-  await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.arguments_charset", "");
+  await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.arguments_charset", "");       // Hidden pref, used?
   await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.enable_new_instance", false);
   await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.prompt.buttons_position", 0);
   await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.icon_color", 0);
   await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.profile.button_launch", "-");
   await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.profiles_sort", true);
-  await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.default_profile_name", "");    // Used ?
   await browser.LegacyPrefs.setDefaultPref("extensions.profileswitcher.profile_manager_shortcut", "");
 
   if (await browser.LegacyPrefs.getPref("extensions.profileswitcher.onload_reset_noremote")) {

--- a/chrome/content/settings.js
+++ b/chrome/content/settings.js
@@ -35,9 +35,6 @@ function initPanel() {
   else
     document.getElementById("titlebar").checked = true;
 
-  var defProf = prefs.getStringPref("extensions.profileswitcher.default_profile_name","");
-  document.getElementById("currDefProfName").value = convToUnicode(defProf);
-
   var profile_in_use = prefs.getStringPref("extensions.profileswitcher.profile.in_use","");
   var profilesListPref = prefs.getStringPref("extensions.profileswitcher.profiles.list","");
   var profileButtonLaunch = prefs.getStringPref("extensions.profileswitcher.profile.button_launch","");

--- a/chrome/content/settings.xhtml
+++ b/chrome/content/settings.xhtml
@@ -137,9 +137,6 @@
     <description>__MSG_iconicTooltipLine4__</description>
     <description>__MSG_iconicTooltipLine5__</description>
   </tooltip>
-  <hbox align="center" collapsed="true">
-    <label value="__MSG_currentDefProf__ " /><label id="currDefProfName" value="" /><image src="PShelp.png"  tooltip="iconic" style="padding-left:10px"   />
-  </hbox>
 </groupbox>
 </vbox>
 </hbox>

--- a/manifest.json
+++ b/manifest.json
@@ -53,7 +53,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "pswitcher2@dillinger",
-      "strict_min_version": "111.0",
+      "strict_min_version": "115.0",
       "strict_max_version": "117.*"
     }
   },


### PR DESCRIPTION
This adds the `commands.onCommand` listener to open the profile manager if the shortcut has been used.

Thunderbird has its own central UI to manage shortcuts, which is available as soon as one add-on registered a shortcut:

![image](https://github.com/dillenger/profile-switcher/assets/5830621/afa0010d-36b4-4574-8910-c34e553246d8)

Since the add-on also allows changing the shortcut in its preferences, these have to be synced. This may be confusing. It works ok, but I think I would remove the sync code and the UI from the settings page and instead add a note how to change the shortcut.

In order to do that, you need to remove the `updateCommands()` function and all places where it is called in the background and also need to remove the `commands.onChanged` listener.

I had to increase the min version to 115.0, because the `commands.onChanged` listener is not supported in 111.